### PR TITLE
Add pytest-automation project card; fix uneven project-grid layout

### DIFF
--- a/_projects/pytest-automation.md
+++ b/_projects/pytest-automation.md
@@ -1,0 +1,19 @@
+---
+order: 1
+title: pytest-automation
+summary: >-
+  A single pytest repo covering API, browser UI, and mobile testing, built to show how pytest
+  marks let CI target one module at a time instead of running the whole mono-repo on every change.
+bullets:
+  - Three test surfaces live in one repo — API (requests, against NASA's NEO API), browser UI (Playwright), and mobile (Appium, against a Sauce Labs demo app)
+  - Custom pytest markers (mobile, android, ios, in_dev) select platform-specific subsets without touching test code
+  - "Goal: a CI pipeline that runs only the module/platform touched by a given change, instead of the full suite every time — workflow wiring is in progress"
+  - Allure reporting across all three surfaces, dependencies managed with uv
+tags:
+  - Python
+  - pytest
+  - Playwright
+  - Appium
+  - Allure
+github: https://github.com/cloffwang/pytest-automation
+---

--- a/_projects/quality-dashboard.md
+++ b/_projects/quality-dashboard.md
@@ -1,5 +1,5 @@
 ---
-order: 1
+order: 2
 title: quality-dashboard
 summary: >-
   A Playwright test suite for a mock "Quality &amp; Uptime Control Center" dashboard, built to

--- a/_projects/selenium-demo.md
+++ b/_projects/selenium-demo.md
@@ -1,5 +1,5 @@
 ---
-order: 2
+order: 3
 title: selenium-demo
 summary: >-
   A Web UI testing framework using Java, Selenium, and Cucumber with a BDD approach.

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -257,7 +257,7 @@ th {
 
 .project-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  grid-template-columns: 1fr;
   gap: 1.25rem;
   margin-top: 1.5rem;
 }


### PR DESCRIPTION
## Summary
- Adds a card for pytest-automation, demonstrating pytest marks (mobile/android/ios/in_dev)
  to select API/UI/mobile test suites independently in a mono-repo; leads the project grid
- Fixes project-grid wrapping into an uneven 2-then-1 layout at wider viewports by switching
  to a single-column stack
- Reorders existing cards: pytest-automation, quality-dashboard, selenium-demo